### PR TITLE
Use hyperlink to replace text url

### DIFF
--- a/Downloads.md
+++ b/Downloads.md
@@ -10,7 +10,7 @@ Tesseract is included in most Linux distributions.
 
 ## Binaries for Windows
 
-https://tesseract-ocr.github.io/tessdoc/4.0-with-LSTM.html#400-alpha-for-windows
+[https://tesseract-ocr.github.io/tessdoc/4.0-with-LSTM.html#400-alpha-for-windows](https://tesseract-ocr.github.io/tessdoc/4.0-with-LSTM.html#400-alpha-for-windows)
 
 ### Old Downloads
 


### PR DESCRIPTION
Though the link can be clicked within GitHub, it can't be clicked when accessed through compiled website. This commit fixed this.