### PR TITLE
spelling mistake

### DIFF
--- a/Command-Line-Usage.md
+++ b/Command-Line-Usage.md
@@ -98,7 +98,7 @@ Using English as primary language and then Hindi
 
 Output
 
-    हिदीसेअंठौजी
+    हिदीसेअंग्रेजी
     HINDI To
     
     ENGLISH


### PR DESCRIPTION
There was spelling mistake for the word 'English' in 'Hindi'