### PR TITLE
Fix typo in Compiling.md

### DIFF
--- a/Compiling.md
+++ b/Compiling.md
@@ -1,6 +1,6 @@
 # Compilation guide for various platforms
 
-**Note:** This documentation expects you to be familiar with compiling software on your operation system.
+**Note:** This documentation expects you to be familiar with compiling software on your operating system.
 
 *Use the same tools for building tesseract as you used for [building leptonica](https://github.com/DanBloomberg/leptonica/issues/410).*
 


### PR DESCRIPTION
This PR fixes a typo in Compiling.md. It used to say “operation system” instead of “operating system”
