### PR TITLE
Add NAPS2 in 3rd party GUIs

### DIFF
--- a/User-Projects-–-3rdParty.md
+++ b/User-Projects-–-3rdParty.md
@@ -30,6 +30,7 @@
 | [TesseractStudio.Net Github](https://github.com/OpaitSoftware/TesseractStudio.Net) |          |         | X           | Proprietary     | (Exe, SourceCode Not Available,Site Urls are Dead) A graphical interface to tesseract 4.0 |
 | [TesseractStudio.Net](https://www.opait.com/TessStudio/index.html) |          |         | X           | Proprietary     |  A graphical interface to tesseract 4.0 |
 | [ImageTrans](https://www.basiccat.org/imagetrans) | X        | X       | X           | Proprietary     |  An image translation tool which can use Tesseract to OCR a whole page, a selected region of an image or a screenshot |
+| [NAPS2](https://www.naps2.com/) | X        | X       | X           | GLP2     |  Scan documents to PDF and more, as simply as possible. |
 
 ## 2. Online OCR services
 


### PR DESCRIPTION
Searching in the issues https://github.com/cyanfish/naps2 and in the forum https://sourceforge.net/p/naps2/discussion/general/ I've found out that this software is problably using Tesseract 4.

Comparing it with other softwares already in the 3rd party list, the results of the OCR are also almost identical.