### PR TITLE
Add link to tesstrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ have information about LSTM integration in Tesseract 4.0x.
 ### Training for Tesseract 5
 
 Training with `tesstrain.sh` (a.k.a tesseract 4 training) in unsupported/abandoned.
-Please use scripts from https://github.com/tesseract-ocr/tesstrain for training.
+Please use scripts from [tesseract-ocr/tesstrain](https://github.com/tesseract-ocr/tesstrain) for training.
 
 - [Train Tesseract LSTM with make from Single Line Images and Groundtruth Transcription](https://github.com/tesseract-ocr/tesstrain)
     * [Examples of Training using tesstrain Makefile](https://github.com/tesseract-ocr/tesstrain/wiki)


### PR DESCRIPTION
Currently, the link is not clickable in the docs deployment:
![image](https://user-images.githubusercontent.com/9874850/224134565-79b022aa-166e-43b0-995d-8be9d04378d8.png)
