### PR TITLE
Update TrainingTesseract-5.md

### DIFF
--- a/tess5/TrainingTesseract-5.md
+++ b/tess5/TrainingTesseract-5.md
@@ -485,6 +485,20 @@ cannot be encoded using the given unicharset. Possible causes are:
 1.  A stray unprintable character (like tab or a control character) in the text.
 1.  There is an un-represented Indic grapheme/aksara in the text.
 
+You can simply remove the offending characters (CHARACTER TABULATION, CARRIAGE RETURN,
+NO-BREAK SPACE, LEFT-TO-RIGHT MARK, RIGHT-TO-LEFT MARK) in pct. 2 with a sed script:
+
+`remove_control_chars.sed`
+```
+s/\x09//g
+s/\x0d//g
+s/\xc2\xa0/ /g
+s/\x20\x0e//g
+s/\x20\x0f//g
+```
+
+`sed -i -f remove_control_chars.sed data/lang--ground-truth*.gt.txt`
+
 In any case it will result in that training image being ignored by the trainer.
 If the error is infrequent, it is harmless, but it may indicate that your
 unicharset is inadequate for representing the language that you are training.

--- a/tess5/TrainingTesseract-5.md
+++ b/tess5/TrainingTesseract-5.md
@@ -486,15 +486,19 @@ cannot be encoded using the given unicharset. Possible causes are:
 1.  There is an un-represented Indic grapheme/aksara in the text.
 
 You can simply remove the offending characters (CHARACTER TABULATION, CARRIAGE RETURN,
-NO-BREAK SPACE, LEFT-TO-RIGHT MARK, RIGHT-TO-LEFT MARK) in pct. 2 with a sed script:
+NO-BREAK SPACE, LEFT-TO-RIGHT MARK, RIGHT-TO-LEFT MARK, ZERO WIDTH NO-BREAK SPACE,
+POP DIRECTIONAL FORMATTING, ZERO WIDTH NON-JOINER) in pct. 2 with a sed script:
 
 `remove_control_chars.sed`
 ```
 s/\x09//g
 s/\x0d//g
-s/\xc2\xa0/ /g
+s/\x00\xa0/ /g
 s/\x20\x0e//g
 s/\x20\x0f//g
+s/\xfe\xff//g
+s/\x20\x2c//g
+s/\x20\x0c//g
 ```
 
 `sed -i -f remove_control_chars.sed data/lang-ground-truth*.gt.txt`

--- a/tess5/TrainingTesseract-5.md
+++ b/tess5/TrainingTesseract-5.md
@@ -497,7 +497,7 @@ s/\x20\x0e//g
 s/\x20\x0f//g
 ```
 
-`sed -i -f remove_control_chars.sed data/lang--ground-truth*.gt.txt`
+`sed -i -f remove_control_chars.sed data/lang-ground-truth*.gt.txt`
 
 In any case it will result in that training image being ignored by the trainer.
 If the error is infrequent, it is harmless, but it may indicate that your


### PR DESCRIPTION
Solution to `Can't encode transcription` error.

```
Encoding of string failed! Failure bytes: c2 a0 e0 a0 93 e0 a0 89 e0 a0 80 e0 a0 84 e0 a0 8b
Can't encode transcription: 'ࠍࠊ⸱ࠉࠄࠉࠅ⸱ࠑࠓࠀࠄ⸱ࠋࠏࠍࠊ⸱ࠉࠄࠉࠅ⸱ࠑࠓࠀࠄ⸱ࠋࠏ ࠓࠉࠀࠄࠋ' in language ''
Encoding of string failed! Failure bytes: c2 a0 e0 a0 93 e0 a0 94 e0 a0 80 e2 b8 b1 e0 a0 8c e0 a0 89 e0 a0 8c e0 a0 84 e2 b8 b1 e0 a0 8d e0 a0 89 e0 a0 81 e0 a0 85 e2 b8 b1 e0 a0 8f e0 a0 89 e0 a0 92 e0 a0 93 e0 a0 8b
Can't encode transcription: 'ࠏࠉࠒࠓࠋ⸱ࠋࠏࠌ ࠓࠔࠀ⸱ࠌࠉࠌࠄ⸱ࠍࠉࠁࠅ⸱ࠏࠉࠒࠓࠋ' in language ''
```

This happens when are present some control characters like:
CHARACTER TABULATION, CARRIAGE RETURN, RIGHT-TO-LEFT MARK [RLM], LEFT-TO-RIGHT MARK [LRM], NO-BREAK SPACE, they are mostly not visible to the naked eye.

Before:

![image](https://github.com/user-attachments/assets/d4618a6c-0560-40a8-a421-15fa411510f7)

After:

![image](https://github.com/user-attachments/assets/de67ff32-3c84-44ff-8d75-1764f9e897ce)
