### PR TITLE
Fix broken markdown link on render HTML

### DIFF
--- a/Compiling.md
+++ b/Compiling.md
@@ -94,7 +94,7 @@ Note that if building Leptonica from source, you may need to ensure that /usr/lo
 
 ## Installing Tesseract from Git
 
-Please follow instructions in [Compiling--GitInstallation](Compiling-%E2%80%93-GitInstallation.md)
+Please follow instructions in [Compiling--GitInstallation](Compiling-%E2%80%93-GitInstallation)
 
 Also read [Install Instructions](https://github.com/tesseract-ocr/tesseract/blob/main/INSTALL.GIT.md)
 


### PR DESCRIPTION
The Git installation instruction links to markdown file. While it working, as redirecting visitor to an unrender markdown, it is not easy to read. I suggest to redirect visitor to a final HTML-rendered page for the best UX.