### PR TITLE
Fix Jekyll link problem

### DIFF
--- a/Compiling.md
+++ b/Compiling.md
@@ -94,7 +94,7 @@ Note that if building Leptonica from source, you may need to ensure that /usr/lo
 
 ## Installing Tesseract from Git
 
-Please follow instructions in [Compiling--GitInstallation](Compiling-%E2%80%93-GitInstallation)
+Please follow instructions in [Compiling--GitInstallation](Compiling-%E2%80%93-GitInstallation.md)
 
 Also read [Install Instructions](https://github.com/tesseract-ocr/tesseract/blob/main/INSTALL.GIT.md)
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-cayman
+plugins:
+  - jekyll-relative-links


### PR DESCRIPTION
This PR does 2 things:

1. reverse previous fix #137 
2. install plugin to convert MD link to HTML link: [`jekyll-relative-links`](https://github.com/benbalter/jekyll-relative-links) 

Credit to **vossad01** from https://stackoverflow.com/a/42914700